### PR TITLE
Auth JWT Access+Refresh Token Strategy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,16 +21,30 @@ func LoadDBConnection() (string, error) {
 	return connectionStr, nil
 }
 
-func LoadJWTSecret() (string, error) {
+func LoadJWTAccessSecret() (string, error) {
 	err := godotenv.Load()
 	if err != nil {
 		return "", err
 	}
 
-	jwtSecret := os.Getenv("JWT_SECRET")
-	if jwtSecret == "" {
+	jwtAccessSecret := os.Getenv("JWT_ACCESS_SECRET")
+	if jwtAccessSecret == "" {
 		return "", errors.New("JWT Secret Not Found")
 	}
 
-	return jwtSecret, nil
+	return jwtAccessSecret, nil
+}
+
+func LoadJWTRefreshSecret() (string, error) {
+	err := godotenv.Load()
+	if err != nil {
+		return "", err
+	}
+
+	jwtRefreshSecret := os.Getenv("JWT_REFRESH_SECRET")
+	if jwtRefreshSecret == "" {
+		return "", errors.New("JWT Refresh Secret Not Found")
+	}
+
+	return jwtRefreshSecret, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	github.com/go-playground/validator v9.31.0+incompatible
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.12.0
@@ -17,6 +17,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp
 github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/auth/auth_handler.go
+++ b/internal/auth/auth_handler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/csusmGDSC/csusmgdsc-api/config"
 	"github.com/csusmGDSC/csusmgdsc-api/internal/db/repositories"
 	"github.com/csusmGDSC/csusmgdsc-api/internal/models"
 	"github.com/google/uuid"
@@ -124,9 +125,14 @@ func AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusUnauthorized, "missing authorization header")
 		}
 
+		jwtAccessSecret, err := config.LoadJWTAccessSecret()
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Internal loading error")
+		}
+
 		// Extract token from "Bearer <token>"
 		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-		claims, err := ValidateJWT(tokenString)
+		claims, err := ValidateJWT(tokenString, []byte(jwtAccessSecret))
 		if err != nil {
 			return echo.NewHTTPError(http.StatusUnauthorized, "invalid token")
 		}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -5,42 +5,62 @@ import (
 
 	"github.com/csusmGDSC/csusmgdsc-api/config"
 	"github.com/csusmGDSC/csusmgdsc-api/internal/models"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
+var (
+	AccessTokenExpiry  = time.Minute * 15   // Short-lived access token
+	RefreshTokenExpiry = time.Hour * 24 * 7 // Long-lived refresh token
+)
+
+// Custom claims to set on JWT https://pkg.go.dev/github.com/golang-jwt/jwt/v4#NewWithClaims
 type Claims struct {
 	UserID string `json:"user_id"`
 	Role   string `json:"role"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 func GenerateJWT(userID string, role models.Role) (string, error) {
 	claims := &Claims{
 		UserID: userID,
 		Role:   role.String(),
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
-			IssuedAt:  time.Now().Unix(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(AccessTokenExpiry)),
 		},
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	jwtSecret, err := config.LoadJWTSecret()
+	jwtAccessSecret, err := config.LoadJWTAccessSecret()
 	if err != nil {
 		return "", err
 	}
 
-	return token.SignedString([]byte(jwtSecret))
+	signedString, err := token.SignedString([]byte(jwtAccessSecret))
+	return signedString, err
 }
 
-func ValidateJWT(tokenString string) (*Claims, error) {
-	jwtSecret, err := config.LoadJWTSecret()
+func GenerateRefreshToken(userID string, role models.Role) (string, error) {
+	claims := &Claims{
+		UserID: userID,
+		Role:   role.String(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(RefreshTokenExpiry)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	jwtRefreshSecret, err := config.LoadJWTRefreshSecret()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
+	signedString, err := token.SignedString([]byte(jwtRefreshSecret))
+	return signedString, err
+}
+
+func ValidateJWT(tokenString string, secret []byte) (*Claims, error) {
+
 	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte(jwtSecret), nil
+		return secret, nil
 	})
 	if err != nil {
 		return nil, err

--- a/internal/db/repositories/refresh_tokens.go
+++ b/internal/db/repositories/refresh_tokens.go
@@ -1,0 +1,51 @@
+package repositories
+
+import (
+	"database/sql"
+
+	"github.com/csusmGDSC/csusmgdsc-api/internal/models"
+)
+
+type RefreshTokenRepository struct {
+	db *sql.DB
+}
+
+func NewRefreshTokenRepository(db *sql.DB) *RefreshTokenRepository {
+	return &RefreshTokenRepository{db: db}
+}
+
+func (r *RefreshTokenRepository) Create(refresh_token *models.CreateSessionRequest) error {
+	query := `
+	    INSERT INTO refresh_tokens(
+		user_id, token, issued_at, expires_at, ip_address, user_agent
+		) VALUES ($1, $2, $3, $4, $5, $6)
+	`
+
+	_, err := r.db.Exec(query,
+		refresh_token.UserID,
+		refresh_token.Token,
+		refresh_token.IssuedAt,
+		refresh_token.ExpiresAt,
+		refresh_token.IPAddress,
+		refresh_token.UserAgent,
+	)
+
+	return err
+}
+
+func (r *RefreshTokenRepository) GetByToken(cookieToken string) (*models.RefreshToken, error) {
+	refreshToken := &models.RefreshToken{}
+	query := `
+	    SELECT token, user_id, expires_at FROM refresh_tokens WHERE token = $1
+	`
+	err := r.db.QueryRow(query, cookieToken).Scan(
+		&refreshToken.Token,
+		&refreshToken.UserID,
+		&refreshToken.ExpiresAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return refreshToken, nil
+}

--- a/internal/models/gdsc_branch.go
+++ b/internal/models/gdsc_branch.go
@@ -3,9 +3,9 @@ package models
 type GDSCBranch int
 
 const (
-	Projects GDSCBranch = iota
-	Interview
-	Marketing
+	Projects  GDSCBranch = iota // 0
+	Interview                   // 1
+	Marketing                   // 2
 )
 
 var GDSCBranchMap = map[GDSCBranch]string{

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type RefreshToken struct {
+	ID        int       `json:"id" db:"id"`
+	UserID    uuid.UUID `json:"user_id" db:"user_id"`
+	Token     string    `json:"token" db:"token"`
+	IssuedAt  time.Time `json:"issued_at" db:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at" db:"expires_at"`
+	IPAddress string    `json:"ip_address,omitempty" db:"ip_address"`
+	UserAgent string    `json:"user_agent,omitempty" db:"user_agent"`
+}
+
+type CreateSessionRequest struct {
+	UserID    uuid.UUID `json:"user_id" db:"user_id"`
+	Token     string    `json:"token" db:"token"`
+	IssuedAt  time.Time `json:"issued_at" db:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at" db:"expires_at"`
+	IPAddress string    `json:"ip_address,omitempty" db:"ip_address"`
+	UserAgent string    `json:"user_agent,omitempty" db:"user_agent"`
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -12,6 +12,7 @@ func InitRoutes(e *echo.Echo) {
 	authGroup := e.Group("/auth")
 	authGroup.POST("/register", handlers.RegisterUser)
 	authGroup.POST("/login", handlers.LoginUser)
+	authGroup.PATCH("/refresh", handlers.RefreshUser)
 	// authGroup.GET("/:provider/login", auth.OAuthLogin)
 	// authGroup.GET("/:provider/callback", auth.OAuthCallback)
 


### PR DESCRIPTION
This PR has the changes that add in JWT Access+Refresh token session management for Oauth

- Created refresh_tokens table in GDSC_DB (one-to-many user to many refresh_tokens)
- Implemented /auth/refresh route to generate new access token
- Updated /auth/login route; generate refresh token, store in db, and set refresh_token httpOnly Cookie
- Added refresh token secret key to .env

Next is to implement logout, logoutAll, deleteUser functionality to complete Oauth implementation

After Oauth2 will be implemented (providers are already registered, routes need to be created)