### PR TITLE
feat: Add logout and logoutAll for Oauth

### DIFF
--- a/internal/db/repositories/refresh_tokens.go
+++ b/internal/db/repositories/refresh_tokens.go
@@ -49,3 +49,25 @@ func (r *RefreshTokenRepository) GetByToken(cookieToken string) (*models.Refresh
 
 	return refreshToken, nil
 }
+
+func (r *RefreshTokenRepository) DeleteByToken(cookieToken string) error {
+	query := `
+		DELETE FROM refresh_tokens WHERE token = $1
+	`
+	_, err := r.db.Exec(query, cookieToken)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RefreshTokenRepository) DeleteAllByUserID(userID string) error {
+	query := `
+		DELETE FROM refresh_tokens WHERE user_id = $1
+	`
+	_, err := r.db.Exec(query, userID)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/db/repositories/user_repo.go
+++ b/internal/db/repositories/user_repo.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"database/sql"
+	"errors"
 	"strings"
 	"time"
 
@@ -249,4 +250,26 @@ func (r *UserRepository) GetByID(id uuid.UUID) (*models.User, error) {
 	}
 
 	return user, nil
+}
+
+func (r *UserRepository) DeleteByID(userID string) error {
+	query := `
+		DELETE FROM users WHERE id = $1
+	`
+
+	result, err := r.db.Exec(query, userID)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("error checking rows affected")
+	}
+
+	return nil
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,6 +13,8 @@ func InitRoutes(e *echo.Echo) {
 	authGroup.POST("/register", handlers.RegisterUser)
 	authGroup.POST("/login", handlers.LoginUser)
 	authGroup.PATCH("/refresh", handlers.RefreshUser)
+	authGroup.POST("/logout", handlers.LogoutUser)
+	authGroup.POST("/logoutAll", handlers.LogoutAll, auth.AuthMiddleware)
 	// authGroup.GET("/:provider/login", auth.OAuthLogin)
 	// authGroup.GET("/:provider/callback", auth.OAuthCallback)
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -18,7 +18,9 @@ func InitRoutes(e *echo.Echo) {
 	// authGroup.GET("/:provider/login", auth.OAuthLogin)
 	// authGroup.GET("/:provider/callback", auth.OAuthCallback)
 
+	// User routes can be used called from User or Admin
 	apiUserGroup := e.Group("/user")
 	apiUserGroup.Use(auth.AuthMiddleware)
 	apiUserGroup.PUT("/update/:id", handlers.UpdateUser)
+	apiUserGroup.DELETE("/delete/:id", handlers.DeleteUser)
 }


### PR DESCRIPTION
Follow up for PR #5 
Logout and LogoutAll routes allow for closing sessions.

Next is delete users to close out Oauth.