### PR TITLE
refactor: update enum types and small user model changes

### DIFF
--- a/internal/models/gdsc_branch.go
+++ b/internal/models/gdsc_branch.go
@@ -2,10 +2,11 @@ package models
 
 type GDSCBranch int
 
+// Enum types must be plus 1 since 0 value in JSON is registered as empty
 const (
-	Projects  GDSCBranch = iota // 0
-	Interview                   // 1
-	Marketing                   // 2
+	Projects GDSCBranch = iota + 1
+	Interview
+	Marketing
 )
 
 var GDSCBranchMap = map[GDSCBranch]string{

--- a/internal/models/gdsc_position.go
+++ b/internal/models/gdsc_position.go
@@ -3,7 +3,7 @@ package models
 type GDSCPosition int
 
 const (
-	Student GDSCPosition = iota
+	Student GDSCPosition = iota + 1
 	Alumni
 	Mentor
 	Leader

--- a/internal/models/room_type.go
+++ b/internal/models/room_type.go
@@ -3,10 +3,10 @@ package models
 type RoomType int
 
 const (
-	Lecture    RoomType = iota // 0
-	Classroom                  // 1
-	Auditorium                 // 2
-	Other                      // 3
+	Lecture    RoomType = iota + 1 // 1
+	Classroom                      // 2
+	Auditorium                     // 3
+	Other                          // 4
 )
 
 var RoomTypeNames = map[RoomType]string{

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -49,6 +49,7 @@ type CreateUserRequest struct {
 	LastName       string       `json:"last_name" validate:"required"`
 	Email          string       `json:"email" validate:"required,email"`
 	Password       string       `json:"password" validate:"required,min=8"`
+	Role           Role         `json:"role,omitempty" validate:"required,oneof=USER ADMIN"`
 	Image          *string      `json:"image,omitempty"`
 	Position       GDSCPosition `json:"position" validate:"required"`
 	Branch         GDSCBranch   `json:"branch" validate:"required"`
@@ -59,7 +60,7 @@ type CreateUserRequest struct {
 	Bio            *string      `json:"bio,omitempty"`
 	Tags           []string     `json:"tags,omitempty"`
 	Website        *string      `json:"website,omitempty"`
-	GraduationDate *time.Time   `json:"graduation_date,omitempty"`
+	GraduationDate *time.Time   `json:"graduation_date,omitempty" validate:"required"`
 }
 
 type UpdateUserRequest struct {


### PR DESCRIPTION
For enum types (iota in Go) we expect to be parsed by JSON, we have to add 1 because a request body that passes a value as "0" will be parsed as "empty" therefore emitted (by user model json rules). Causing the request to be invalid.

EX: A new user who wants position to be "Member" (internal/models/gdsc_position.go) 
Request body to "/auth/register"
{
    "email": "test.user@csusm.edu",
    "first_name": "Test",
    "last_name": "User",
    "password": "ExamplePassword123",
    "role": "USER",
    "position": 0,
    "branch": 1,
    "graduation_date": "2024-05-15T00:00:00Z"
}

The previous code would fail return an invalid request error because the position binding is omitted.


