### PR TITLE
Update Registration Flow

### DIFF
--- a/internal/auth/auth_handlers/auth_handler.go
+++ b/internal/auth/auth_handlers/auth_handler.go
@@ -2,7 +2,6 @@ package auth_handlers
 
 import (
 	"database/sql"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -310,12 +309,6 @@ func (h *OAuthHandler) OAuthCallback(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Failed to authenticate"})
 	}
-
-	fmt.Println("ID: ", userData.ID)
-	fmt.Println("Name: ", userData.Name)
-	fmt.Println("Email: ", userData.Email)
-	fmt.Println("AvatarURL: ", *userData.AvatarURL)
-	fmt.Println("Provider: ", userData.Provider)
 
 	dbConn := h.DB.GetDB()
 	userRepo := auth_repositories.NewUserRepository(dbConn)

--- a/internal/auth/auth_models/oauth_register.go
+++ b/internal/auth/auth_models/oauth_register.go
@@ -1,0 +1,1 @@
+package auth_models

--- a/internal/auth/auth_models/traditional_register.go
+++ b/internal/auth/auth_models/traditional_register.go
@@ -1,0 +1,1 @@
+package auth_models

--- a/internal/auth/auth_models/user.go
+++ b/internal/auth/auth_models/user.go
@@ -6,11 +6,17 @@ import (
 	"github.com/csusmGDSC/csusmgdsc-api/internal/models"
 )
 
-type CreateUserRequest struct {
-	Email    string  `json:"email" validate:"required,email"`
-	Password *string `json:"password,omitempty"`
+type CreateUserTraditionalAuthRequest struct {
+	Email    *string `json:"email" validate:"required,email"`
+	Password *string `json:"password,omitempty" validate:"required"`
+}
+
+type CreateUserOAuthRequest struct {
+	Email    *string `json:"email"`
 	Provider *string `json:"provider,omitempty"`
 	AuthID   *string `json:"auth_id,omitempty"`
+	Image    *string `json:"image,omitempty"`
+	Name     *string `json:"name,omitempty"`
 }
 
 type LoginRequest struct {

--- a/internal/auth/auth_models/user.go
+++ b/internal/auth/auth_models/user.go
@@ -12,7 +12,7 @@ type CreateUserTraditionalAuthRequest struct {
 }
 
 type CreateUserOAuthRequest struct {
-	Email    *string `json:"email"`
+	Email    *string `json:"email,omitempty"`
 	Provider *string `json:"provider,omitempty"`
 	AuthID   *string `json:"auth_id,omitempty"`
 	Image    *string `json:"image,omitempty"`

--- a/internal/auth/auth_repositories/user_repo.go
+++ b/internal/auth/auth_repositories/user_repo.go
@@ -23,7 +23,7 @@ func NewUserRepository(db *sql.DB) *UserRepository {
 func (r *UserRepository) Create(user *models.User) error {
 	query := `
 		INSERT INTO users (
-			id, full_name, email, password, provider, auth_id,created_at, updated_at, is_onboarded
+			id, full_name, email, password, provider, auth_id, created_at, updated_at, is_onboarded
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
 

--- a/internal/auth/auth_repositories/user_repo.go
+++ b/internal/auth/auth_repositories/user_repo.go
@@ -23,7 +23,7 @@ func NewUserRepository(db *sql.DB) *UserRepository {
 func (r *UserRepository) Create(user *models.User) error {
 	query := `
 		INSERT INTO users (
-			id, full_name, email, password, provider, auth_id,created_at, updated_at
+			id, full_name, email, password, provider, auth_id,created_at, updated_at, is_onboarded
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
 
@@ -227,7 +227,7 @@ func (r *UserRepository) GetByAuthID(authID string) (*models.User, error) {
 		SELECT id, full_name, first_name, last_name, email, password,
 		 	role, position, branch, image, github,
 			linkedin, instagram, discord, bio, tags, website,
-			graduation_date, created_at, updated_at, provider, auth_id
+			graduation_date, created_at, updated_at, provider, auth_id, is_onboarded
 		FROM users
 		WHERE auth_id = $1
 	`
@@ -255,6 +255,7 @@ func (r *UserRepository) GetByAuthID(authID string) (*models.User, error) {
 		&user.UpdatedAt,
 		&user.Provider,
 		&user.AuthID,
+		&user.IsOnboarded,
 	)
 
 	if err != nil {

--- a/internal/auth/auth_utils/traditional_auth.go
+++ b/internal/auth/auth_utils/traditional_auth.go
@@ -19,10 +19,10 @@ var (
 	ErrInvalidToken       = errors.New("invalid token")
 )
 
-func RegisterUserToDatabase(db *sql.DB, req auth_models.CreateUserRequest) (*models.User, error) {
+func RegisterUserTraditionalAuthToDatabase(db *sql.DB, req auth_models.CreateUserTraditionalAuthRequest) (*models.User, error) {
 	userRepo := auth_repositories.NewUserRepository(db)
 
-	exists, err := userRepo.EmailExists(req.Email)
+	exists, err := userRepo.EmailExists(*req.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func RegisterUserToDatabase(db *sql.DB, req auth_models.CreateUserRequest) (*mod
 		return nil, ErrUserExists
 	}
 
-	if req.Password != nil && req.AuthID == nil && req.Provider == nil {
+	if req.Password != nil {
 		hashedPassword, err := HashPassword(*req.Password)
 		if err != nil {
 			return nil, err
@@ -39,13 +39,12 @@ func RegisterUserToDatabase(db *sql.DB, req auth_models.CreateUserRequest) (*mod
 	}
 
 	user := &models.User{
-		ID:        uuid.New(),
-		Email:     req.Email,
-		Password:  req.Password,
-		Provider:  req.Provider,
-		AuthID:    req.AuthID,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		ID:          uuid.New(),
+		Email:       *req.Email,
+		Password:    req.Password,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+		IsOnboarded: false,
 	}
 
 	err = userRepo.Create(user)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -43,13 +43,3 @@ type User struct {
 	AuthID         *string        `json:"auth_id" db:"auth_id"`
 	IsOnboarded    bool           `json:"is_onboarded" db:"is_onboarded"`
 }
-
-type CompleteOAuthRegistrationRequest struct {
-	TempToken      string       `json:"temp_token" validate:"required"`
-	Position       GDSCPosition `json:"position" validate:"required"`
-	Branch         GDSCBranch   `json:"branch" validate:"required"`
-	GraduationDate time.Time    `json:"graduation_date" validate:"required"`
-	FirstName      string       `json:"first_name" validate:"required"`
-	LastName       string       `json:"last_name" validate:"required"`
-	Email          string       `json:"email" validate:"required"`
-}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -41,6 +41,7 @@ type User struct {
 	UpdatedAt      time.Time      `json:"updated_at" db:"updated_at"`
 	Provider       *string        `json:"provider" db:"provider"`
 	AuthID         *string        `json:"auth_id" db:"auth_id"`
+	IsOnboarded    bool           `json:"is_onboarded" db:"is_onboarded"`
 }
 
 type CompleteOAuthRegistrationRequest struct {


### PR DESCRIPTION
Closes #27 
This PR changes Registration logic by updating /auth/register and /auth/:provider/callback, both now create a new user in our database.

Route: /auth/register now only requires a email + password to create a user
Route: /auth/:provider/callback now only requires a provider + authID to generate a new user 
    - additional user information from provider is attached if given but will not prevent user creation

Additionally:
    - registration to database is split up to traditional auth and OAuth auth
    - User model creation request types are split between traditional and OAuth
    - Database users table is updated to have "is_onboarded" field
    - Role by default will be "USER"