### PR TITLE
Update OAuth Callback to Redirect to Frontend

### DIFF
--- a/internal/auth/auth_handlers/auth_handler.go
+++ b/internal/auth/auth_handlers/auth_handler.go
@@ -2,7 +2,9 @@ package auth_handlers
 
 import (
 	"database/sql"
+	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/csusmGDSC/csusmgdsc-api/config"
@@ -377,8 +379,16 @@ func (h *OAuthHandler) OAuthCallback(c echo.Context) error {
 	cookie.Expires = expiresAt
 	c.SetCookie(cookie)
 
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"accessToken": accessToken,
-		"user":        user,
-	})
+	frontendURL := "https://gdsc-csusm.com"
+
+	if !user.IsOnboarded {
+		frontendURL = frontendURL + "/onboarding"
+	}
+
+	redirectURL := fmt.Sprintf("%s?token=%s",
+		frontendURL,
+		url.QueryEscape(accessToken),
+	)
+
+	return c.Redirect(http.StatusTemporaryRedirect, redirectURL)
 }


### PR DESCRIPTION
Previous implementation of OAuthCallback returns to callback url rather than caller url.  This change makes it so that after successful provider login the user is redirected to the frontend.

The redirect depends on whether the user has been onboarded (IsOnboarded /internal/auth/models/user.go), if they have not, redirect to https://gdsc-csusm.com/onboarding, else redirect to https://gdsc-csusm.com

temporary access token is provided via query param.