### PR TITLE
Set ADMIN OPTION on CI User to Allow DROP on Temp User

### DIFF
--- a/.github/workflows/assign-db-access.yml
+++ b/.github/workflows/assign-db-access.yml
@@ -15,14 +15,15 @@ jobs:
 
       - name: Create a temporary database role
         run: |
-          DB_URL="postgres://${{ secrets.NEON_DB_USER }}:${{ secrets.NEON_DB_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
+          DB_URL="postgres://${{ secrets.NEON_DB_ADMIN_USER }}:${{ secrets.NEON_DB_ADMIN_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
           TEMP_PASS=$(openssl rand -base64 12)
 
           # Quote the contributor's name to handle special characters like '-'
           psql "$DB_URL" -c "CREATE ROLE \"dev_${{ env.CONTRIBUTOR }}\" WITH LOGIN PASSWORD '$TEMP_PASS';"
-          psql "$DB_URL" -c "GRANT CONNECT ON DATABASE test TO \"dev_${{ env.CONTRIBUTOR }}\";"
+          psql "$DB_URL" -c "GRANT CONNECT ON DATABASE "GDSC_DB" TO \"dev_${{ env.CONTRIBUTOR }}\";"
           psql "$DB_URL" -c "GRANT USAGE ON SCHEMA public TO \"dev_${{ env.CONTRIBUTOR }}\";"
           psql "$DB_URL" -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"dev_${{ env.CONTRIBUTOR }}\";"
+          psql "$DB_URL" -c "GRANT \"dev_${{ env.CONTRIBUTOR }}\" TO ${{ secrets.NEON_DB_USER}} WITH ADMIN OPTION;"
 
           echo "TEMP_PASS=$TEMP_PASS" >> $GITHUB_ENV
 

--- a/.github/workflows/revoke-db-access.yml
+++ b/.github/workflows/revoke-db-access.yml
@@ -24,5 +24,10 @@ jobs:
       - name: Remove temporary role
         run: |
           DB_URL="postgres://${{ secrets.NEON_DB_USER }}:${{ secrets.NEON_DB_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
-          # Drop the temporary role, quoting it to handle special characters like '-'
+          # Revoke privileges from temporary role
+          psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON DATABASE \"GDSC_DB\" FROM \"dev_${{ env.CONTRIBUTOR }}\";"
+          psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON SCHEMA public FROM \"dev_${{ env.CONTRIBUTOR }}\";"
+          psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"dev_${{ env.CONTRIBUTOR }}\";"
+          
+          # Drop the temporary role
           psql "$DB_URL" -c "DROP ROLE IF EXISTS \"dev_${{ env.CONTRIBUTOR }}\";"

--- a/.github/workflows/revoke-db-access.yml
+++ b/.github/workflows/revoke-db-access.yml
@@ -21,13 +21,15 @@ jobs:
             echo "CONTRIBUTOR=${{ github.event.pull_request.user.login }}" >> $GITHUB_ENV
           fi
 
-      - name: Remove temporary role
+      - name: Revoke temp user privileges
         run: |
-          DB_URL="postgres://${{ secrets.NEON_DB_USER }}:${{ secrets.NEON_DB_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
-          # Revoke privileges from temporary role
+          DB_URL="postgres://${{ secrets.NEON_DB_ADMIN_USER }}:${{ secrets.NEON_DB_ADMIN_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
           psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON DATABASE \"GDSC_DB\" FROM \"dev_${{ env.CONTRIBUTOR }}\";"
           psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON SCHEMA public FROM \"dev_${{ env.CONTRIBUTOR }}\";"
           psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"dev_${{ env.CONTRIBUTOR }}\";"
-          
+      
+          - name: Remove temporary role
+          run: |
+          DB_URL="postgres://${{ secrets.NEON_DB_USER }}:${{ secrets.NEON_DB_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
           # Drop the temporary role
           psql "$DB_URL" -c "DROP ROLE IF EXISTS \"dev_${{ env.CONTRIBUTOR }}\";"


### PR DESCRIPTION
The GDSC Owner User creates the temp user and allows github_ci user to have ADMIN OPTION on temp, DROP temp user using github_ci user after revoking permissions.