### PR TITLE
refactor: remove temporary token logic

### DIFF
--- a/internal/auth/auth_utils/jwt.go
+++ b/internal/auth/auth_utils/jwt.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/csusmGDSC/csusmgdsc-api/config"
-	"github.com/csusmGDSC/csusmgdsc-api/internal/auth"
 	"github.com/csusmGDSC/csusmgdsc-api/internal/auth/auth_models"
 	"github.com/csusmGDSC/csusmgdsc-api/internal/auth/auth_repositories"
 	"github.com/csusmGDSC/csusmgdsc-api/internal/models"
@@ -14,15 +13,9 @@ import (
 )
 
 var (
-	AccessTokenExpiry    = time.Minute * 15   // Short-lived access token
-	RefreshTokenExpiry   = time.Hour * 24 * 7 // Long-lived refresh token
-	TemporaryTokenExpiry = time.Minute * 15   // Short-lived temporary token
+	AccessTokenExpiry  = time.Minute * 15   // Short-lived access token
+	RefreshTokenExpiry = time.Hour * 24 * 7 // Long-lived refresh token
 )
-
-type TempTokenClaims struct {
-	OAuthUserData *auth.OAuthUserData `json:"oauth_data"`
-	jwt.RegisteredClaims
-}
 
 // Custom claims to set on JWT https://pkg.go.dev/github.com/golang-jwt/jwt/v4#NewWithClaims
 type Claims struct {
@@ -71,39 +64,6 @@ func GenerateRefreshToken(userID uuid.UUID, role *models.Role) (string, time.Tim
 	cfg := config.LoadConfig()
 	signedString, err := token.SignedString([]byte(cfg.JWTRefreshSecret))
 	return signedString, issuedAt.Time, expiresAt.Time, err
-}
-
-func GenerateTemporaryToken(oauthData *auth.OAuthUserData) (string, error) {
-	claims := &TempTokenClaims{
-		OAuthUserData: oauthData,
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(TemporaryTokenExpiry)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			NotBefore: jwt.NewNumericDate(time.Now()),
-		},
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	cfg := config.LoadConfig()
-
-	return token.SignedString([]byte(cfg.JWTAccessSecret))
-}
-
-func ValidateTemporaryToken(tokenString string) (*TempTokenClaims, error) {
-	cfg := config.LoadConfig()
-
-	token, err := jwt.ParseWithClaims(tokenString, &TempTokenClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte(cfg.JWTAccessSecret), nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if claims, ok := token.Claims.(*TempTokenClaims); ok && token.Valid {
-		return claims, nil
-	}
-
-	return nil, ErrInvalidToken
 }
 
 func CreateSession(db *sql.DB, req auth_models.CreateSessionRequest) error {


### PR DESCRIPTION
Cleaning up jwt.go, temporary token no longer being used.