### PR TITLE
fix: dynamically set neon dev branch in CI workflows

### DIFF
--- a/.github/workflows/assign-db-access.yml
+++ b/.github/workflows/assign-db-access.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Create a Temporary Database Role
         run: |
-          DB_URL="postgres://${{ secrets.NEON_DB_ADMIN_USER }}:${{ secrets.NEON_DB_ADMIN_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
+          DB_URL="postgres://${{ secrets.NEON_DB_ADMIN_USER }}:${{ secrets.NEON_DB_ADMIN_PASSWORD }}@${{ vars.NEON_DB_BRANCH_ID }}.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
           TEMP_PASS=$(openssl rand -base64 12)
 
           # Quote the contributor's name to handle special characters like '-'
@@ -48,7 +48,7 @@ jobs:
             - **Connection String**:
 
             ```
-            postgres://dev_${{ env.CONTRIBUTOR }}:${{ env.TEMP_PASS }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require
+            postgres://dev_${{ env.CONTRIBUTOR }}:${{ env.TEMP_PASS }}@${{ vars.NEON_DB_BRANCH_ID }}.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require
             ```
             
             :sparkles:Use this connection string while working on this issue!:sparkles:

--- a/.github/workflows/revoke-db-access.yml
+++ b/.github/workflows/revoke-db-access.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Revoke Temp User Privileges
         run: |
-          DB_URL="postgres://${{ secrets.NEON_DB_ADMIN_USER }}:${{ secrets.NEON_DB_ADMIN_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
+          DB_URL="postgres://${{ secrets.NEON_DB_ADMIN_USER }}:${{ secrets.NEON_DB_ADMIN_PASSWORD }}@${{ vars.NEON_DB_BRANCH_ID }}.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
           psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON DATABASE \"GDSC_DB\" FROM \"dev_${{ env.CONTRIBUTOR }}\";"
           psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON SCHEMA public FROM \"dev_${{ env.CONTRIBUTOR }}\";"
           psql "$DB_URL" -c "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"dev_${{ env.CONTRIBUTOR }}\";"
@@ -31,6 +31,6 @@ jobs:
       
       - name: Remove Temporary Role
         run: |
-          DB_URL="postgres://${{ secrets.NEON_DB_USER }}:${{ secrets.NEON_DB_PASSWORD }}@ep-dawn-butterfly-a6u946g4.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
+          DB_URL="postgres://${{ secrets.NEON_DB_USER }}:${{ secrets.NEON_DB_PASSWORD }}@${{ vars.NEON_DB_BRANCH_ID }}.us-west-2.aws.neon.tech/GDSC_DB?sslmode=require"
           # Drop the temporary role
           psql "$DB_URL" -c "DROP ROLE IF EXISTS \"dev_${{ env.CONTRIBUTOR }}\";"


### PR DESCRIPTION
CI workflow is breaking due to compute hours on neon branch being exhausted, ci workflows will be determined by a GitHub variable, so we can change the dev branch easily and without editing the code.